### PR TITLE
Add continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
 
-    - uses: actions/cache@v2
-      name: Load pip cache
-      id: cache-pip
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt') }}
-
-
     - name: Install pip
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Continuous Integration
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+
+    - uses: actions/cache@v2
+      name: Load pip cache
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt') }}
+
+
+    - name: Install pip
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+        pip install tables
+
+    - name: Run test data file
+      run: |
+        export BPZDATAPATH=$PWD
+        cd tests
+        python ../scripts/bpz.py test1000.h5 -P test1000.pars

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: Continuous Integration
 
 on:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DESC_BPZ: 
 
-This repo contains a python3 port of the popular BPZ softwrae package (https://www.stsci.edu/~dcoe/BPZ/).  The code was modified from the original bpz-1.99.3 version available at the given URL, upgraded to be python3 compatible, and modified to read and write hdf5 files rather than straight ascii.  The code is messy in many places, having gone through multiple iterations by multiple authors.  No promises are made as to functionality of multiple subsystems (e.g. plotting), so use with caution!
+This repo contains a python3 port of the popular BPZ software package (https://www.stsci.edu/~dcoe/BPZ/).  The code was modified from the original bpz-1.99.3 version available at the given URL, upgraded to be python3 compatible, and modified to read and write hdf5 files rather than straight ascii.  The code is messy in many places, having gone through multiple iterations by multiple authors.  No promises are made as to functionality of multiple subsystems (e.g. plotting), so use with caution!
 
 If you use this code, please cite [Benitez (2000)](https://ui.adsabs.harvard.edu/abs/2000ApJ...536..571B/abstract) and [Coe et al. (2006)](https://ui.adsabs.harvard.edu/abs/2006AJ....132..926C/abstract).
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     install_requires=['numpy',
                       'scipy',
                       'pandas>=1.1',
+                      'h5py',
                       ],
     python_requires='>=3.5',
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
This adds a CI to desc_bpz, mainly so I can show that my next PR doesn't break anything.  it runs the test data that comes with the repo.  Right now it just checks that bpz.py runs okay, and doesn't check results values.