### PR TITLE
change inf nan and alltrue to np2.0 compatible equivalents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11]
+        python-version: [3.9, "3.10", "3.11"]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.9, 3.10, 3.11]
 
     steps:
     - name: Checkout repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Operating System :: OS Independent"
 ]
 dependencies = [
-    "numpy",
+    "numpy<2.0",
     "scipy",
     "pandas>=1.1",
     "h5py",

--- a/src/desc_bpz/MLab_coe_py3.py
+++ b/src/desc_bpz/MLab_coe_py3.py
@@ -479,8 +479,8 @@ def within(A, xc, yc, ro, yesorno=0):  # --DC
     x = x-xc + 0.
     y = y-yc + 0.
     r = hypot(x,y)
-    xy = abs(divsafe(x, y, nan=0))
-    yx = abs(divsafe(y, x, nan=0))
+    xy = abs(divsafe(x, y, nanx=0))
+    yx = abs(divsafe(y, x, nanx=0))
     m = min([xy, yx])
     dr = hypot(1, m)  # = 1 ON AXES, sqrt(2) ON DIAGONALS
 
@@ -685,8 +685,8 @@ def rotdeg(x, y, ang):
 def linefit(x1, y1, x2, y2):
     """y = mx + b FIT TO TWO POINTS"""
     if x2 == x1:
-        m = Inf
-        b = NaN
+        m = inf
+        b = nan
     else:
         m = (y2 - y1) / (x2 - x1)
         b = y1 - m * x1
@@ -852,7 +852,7 @@ def gauss1(r, sig=1.):
 
 def atanxy(x, y, degrees=0):
     """ANGLE CCW FROM x-axis"""
-    theta = arctan(divsafe(y, x, inf=1e30, nan=0))
+    theta = arctan(divsafe(y, x, infx=1e30, nanx=0))
     theta = where(less(x, 0), theta + pi, theta)
     theta = where(logical_and(greater(x, 0), less(y, 0)), theta + 2*pi, theta)
     if degrees:
@@ -964,7 +964,7 @@ def sym8(a):
     return x / 8.
 
 #def divsafe(a, b, inf=1e30, nan=0.):
-def divsafe(a, b, inf=Inf, nan=NaN):
+def divsafe(a, b, infx=inf, nanx=nan):
     """a / b with a / 0 = inf and 0 / 0 = nan"""
     a = array(a).astype(float)
     b = array(b).astype(float)
@@ -976,7 +976,7 @@ def divsafe(a, b, inf=Inf, nan=NaN):
     babs = clip(abs(b), 1e-200, 1e9999)
     bb = bsgn * babs
     #return where(b, a / bb, where(a, Inf, NaN))
-    return where(b, a / bb, where(a, sgn*inf, nan))
+    return where(b, a / bb, where(a, sgn*infx, nanx))
 
 def expsafe(x):
     x = array(x)
@@ -1205,7 +1205,7 @@ def norepxy(x, y, tol=1e-8):
 
 def isseq(a):
     """TELLS YOU IF a IS SEQUENTIAL, LIKE [3, 4, 5, 6]"""
-    return (alltrue(a == arange(len(a)) + a[0]))
+    return (all(a == arange(len(a)) + a[0]))
 
 def between(lo, x, hi):  # --DC
     # RETURNS 1 WHERE lo < x < hi
@@ -1262,7 +1262,7 @@ def interp(x, xdata, ydata, silent=0, extrap=0):  # NEW VERSION!
     y2 = take(ydata, i2)
     y1 = take(ydata, i1)
     # m = (y2 - y1) / (x2 - x1)
-    m = divsafe(y2 - y1, x2 - x1, nan=0)
+    m = divsafe(y2 - y1, x2 - x1, nanx=0)
     b = y1 - m * x1
     y = m * x + b
     if len(y) == 0:

--- a/src/desc_bpz/MLab_coe_py3.py
+++ b/src/desc_bpz/MLab_coe_py3.py
@@ -479,8 +479,8 @@ def within(A, xc, yc, ro, yesorno=0):  # --DC
     x = x-xc + 0.
     y = y-yc + 0.
     r = hypot(x,y)
-    xy = abs(divsafe(x, y, nanx=0))
-    yx = abs(divsafe(y, x, nanx=0))
+    xy = abs(divsafe(x, y, nan=0))
+    yx = abs(divsafe(y, x, nan=0))
     m = min([xy, yx])
     dr = hypot(1, m)  # = 1 ON AXES, sqrt(2) ON DIAGONALS
 
@@ -852,7 +852,7 @@ def gauss1(r, sig=1.):
 
 def atanxy(x, y, degrees=0):
     """ANGLE CCW FROM x-axis"""
-    theta = arctan(divsafe(y, x, infx=1e30, nanx=0))
+    theta = arctan(divsafe(y, x, inf=1e30, nan=0))
     theta = where(less(x, 0), theta + pi, theta)
     theta = where(logical_and(greater(x, 0), less(y, 0)), theta + 2*pi, theta)
     if degrees:
@@ -964,7 +964,7 @@ def sym8(a):
     return x / 8.
 
 #def divsafe(a, b, inf=1e30, nan=0.):
-def divsafe(a, b, infx=inf, nanx=nan):
+def divsafe(a, b, inf=inf, nan=nan):
     """a / b with a / 0 = inf and 0 / 0 = nan"""
     a = array(a).astype(float)
     b = array(b).astype(float)
@@ -976,7 +976,7 @@ def divsafe(a, b, infx=inf, nanx=nan):
     babs = clip(abs(b), 1e-200, 1e9999)
     bb = bsgn * babs
     #return where(b, a / bb, where(a, Inf, NaN))
-    return where(b, a / bb, where(a, sgn*infx, nanx))
+    return where(b, a / bb, where(a, sgn*inf, nan))
 
 def expsafe(x):
     x = array(x)
@@ -1262,7 +1262,7 @@ def interp(x, xdata, ydata, silent=0, extrap=0):  # NEW VERSION!
     y2 = take(ydata, i2)
     y1 = take(ydata, i1)
     # m = (y2 - y1) / (x2 - x1)
-    m = divsafe(y2 - y1, x2 - x1, nanx=0)
+    m = divsafe(y2 - y1, x2 - x1, nan=0)
     b = y1 - m * x1
     y = m * x + b
     if len(y) == 0:

--- a/src/desc_bpz/coeio_py3.py
+++ b/src/desc_bpz/coeio_py3.py
@@ -1849,7 +1849,7 @@ def loadsexcat(infile, purge=1, maxflags=8, minfwhm=1, minrf=0, maxmag=99, magna
     if not silent:
         print(sum(good))
 
-    if purge and not alltrue(good):
+    if purge and not all(good):
         data = compress(good, data)
         if (flags != None): flags = compress(good, flags)
         if (mag != None): mag = compress(good, mag)

--- a/src/desc_bpz/scripts/bpz.py
+++ b/src/desc_bpz/scripts/bpz.py
@@ -487,7 +487,7 @@ if pars.d['MAG']=='yes':
         print("""Allowed values for magnitudes are 
         0<m<"""+repr(undet)+" m="+repr(undet)+"(non detection), m="+repr(unobs)+"(not observed)") 
         for i in range(len(todo)):
-            if not alltrue(todo[i,:]):
+            if not all(todo[i,:]):
                 print(i+1,f_obs[i,:],ef_obs[i,:])
         sys.exit()
  

--- a/src/desc_bpz/scripts/bpz.py
+++ b/src/desc_bpz/scripts/bpz.py
@@ -1395,7 +1395,7 @@ for ig in range(ng):
         #texto='%s ' % str(id[ig])
         #texto+= len(p_bayes)*'%.3e '+'\n'
         #probs.write(texto % tuple(p_bayes))
-        idwrite[ig] = np.int(id[ig])
+        idwrite[ig] = np.int64(id[ig])
         probswrite[ig] = p_bayes
         
         #if ig<ng-1: 

--- a/src/desc_bpz/useful_py3.py
+++ b/src/desc_bpz/useful_py3.py
@@ -396,7 +396,7 @@ def ascend(x):
        Recommended usage: 
        if not ascend(x): sort(x) 
     """
-    return alltrue(greater_equal(x[1:],x[0:-1]))
+    return all(greater_equal(x[1:],x[0:-1]))
 
 
 #def match_resol(xg,yg,xf,method="linear"):


### PR DESCRIPTION
Addresses #17 by changing Inf to inf, NaN to nan, and alltrue to all, as Inf, NaN, and alltrue have been dropped from the new numpy2.0 release.  Passes all tests with rail_bpz, and I ran the rail_bpz quick demo notebook and everything looked as expected, so this should be good to go.