### PR TITLE
remove <2 from numpy version dependence, add tables dep.  Addresses #21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,11 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
-    "numpy<2.0",
+    "numpy",
     "scipy",
     "pandas>=1.1",
     "h5py",
+    "tables",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python",
 ]
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "numpy",
     "scipy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "scipy",
     "pandas>=1.1",
     "h5py",
-    "tables",
 ]
 
 [project.urls]


### PR DESCRIPTION
for issue #21 , just removes the <2.0 from numpy dependence.  I noticed that we need pytables as well, so I added tables to the pyproject.toml.  

Currently, qp and rail_base tagged versions on pypi still have the numpy<2.0, so this won't change anything on the Github Action (unless we tag qp and rail_base with new releases), but I did run both the DESC_BPZ demo run and the rail_bpz demo notebook and both produced identical results with numpy 2.2.1 and 1.26.4, so this should be fine.